### PR TITLE
Wrap native preload to fix screenshare issues like #20

### DIFF
--- a/dom_shit.js
+++ b/dom_shit.js
@@ -1,5 +1,8 @@
 const path = window.require('path');
 const fs = window.require('fs');
+const electron = window.require('electron');
+const currentWindow = electron.remote.getCurrentWindow();
+if (currentWindow.__preload) require(currentWindow.__preload);
 
 //set up global functions
 let c = {

--- a/installer/EnhancedDiscordUI/Properties/Resources.resx
+++ b/installer/EnhancedDiscordUI/Properties/Resources.resx
@@ -156,13 +156,16 @@ class PatchedBrowserWindow extends BrowserWindow {
     constructor(originalOptions) {
         const options = Object.create(originalOptions);
         options.webPreferences = Object.create(options.webPreferences);
+		
+		const originalPreloadScript = options.webPreferences.preload;
 
         // Make sure Node integration is enabled
         options.webPreferences.nodeIntegration = true;
         options.webPreferences.preload = path.join(process.env.injDir, 'dom_shit.js');
         options.webPreferences.transparency = true;
 
-        return new BrowserWindow(options);
+        super(options);
+        this.__preload = originalPreloadScript;
     }
 }
 


### PR DESCRIPTION
Wraps the native preloader into ED so discord's preload is still run and the app can no longer complain. Would fix #20 