### PR TITLE
Fix CSP with bypass + Restyle installer + Add update functionality (to installer)

### DIFF
--- a/dom_shit.js
+++ b/dom_shit.js
@@ -4,6 +4,8 @@ const electron = window.require('electron');
 const currentWindow = electron.remote.getCurrentWindow();
 if (currentWindow.__preload) require(currentWindow.__preload);
 
+electron.webFrame.registerURLSchemeAsBypassingCSP('https');
+
 //set up global functions
 let c = {
     log: function(msg, plugin) {

--- a/installer/EnhancedDiscordUI/Form1.Designer.cs
+++ b/installer/EnhancedDiscordUI/Form1.Designer.cs
@@ -110,6 +110,7 @@
             this.UpdateButton.Text = "Update";
             this.toolTip1.SetToolTip(this.UpdateButton, "Replaces the ED files with the most recent ones [Coming Soon™]");
             this.UpdateButton.UseVisualStyleBackColor = true;
+            this.UpdateButton.Click += new System.EventHandler(this.UpdateButton_Click);
             // 
             // InstallProgress
             // 

--- a/installer/EnhancedDiscordUI/Form1.Designer.cs
+++ b/installer/EnhancedDiscordUI/Form1.Designer.cs
@@ -54,10 +54,11 @@
             this.InstallButton.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.InstallButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.InstallButton.Font = new System.Drawing.Font("Consolas", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.InstallButton.ForeColor = System.Drawing.Color.Yellow;
-            this.InstallButton.Location = new System.Drawing.Point(155, 127);
+            this.InstallButton.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.InstallButton.Location = new System.Drawing.Point(116, 103);
+            this.InstallButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.InstallButton.Name = "InstallButton";
-            this.InstallButton.Size = new System.Drawing.Size(130, 30);
+            this.InstallButton.Size = new System.Drawing.Size(98, 24);
             this.InstallButton.TabIndex = 0;
             this.InstallButton.Text = "Install";
             this.toolTip1.SetToolTip(this.InstallButton, "Downloads and injects ED into your Discord client.");
@@ -68,10 +69,11 @@
             // 
             this.Title.AutoSize = true;
             this.Title.Font = new System.Drawing.Font("Consolas", 18F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.Title.ForeColor = System.Drawing.Color.Gold;
-            this.Title.Location = new System.Drawing.Point(131, 16);
+            this.Title.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.Title.Location = new System.Drawing.Point(98, 13);
+            this.Title.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.Title.Name = "Title";
-            this.Title.Size = new System.Drawing.Size(255, 36);
+            this.Title.Size = new System.Drawing.Size(207, 28);
             this.Title.TabIndex = 1;
             this.Title.Text = "EnhancedDiscord";
             // 
@@ -79,13 +81,14 @@
             // 
             this.UninstallButton.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.UninstallButton.Enabled = false;
-            this.UninstallButton.FlatAppearance.BorderColor = System.Drawing.Color.Yellow;
+            this.UninstallButton.FlatAppearance.BorderColor = System.Drawing.Color.WhiteSmoke;
             this.UninstallButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.UninstallButton.Font = new System.Drawing.Font("Consolas", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.UninstallButton.ForeColor = System.Drawing.Color.Yellow;
-            this.UninstallButton.Location = new System.Drawing.Point(155, 163);
+            this.UninstallButton.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.UninstallButton.Location = new System.Drawing.Point(116, 132);
+            this.UninstallButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.UninstallButton.Name = "UninstallButton";
-            this.UninstallButton.Size = new System.Drawing.Size(130, 30);
+            this.UninstallButton.Size = new System.Drawing.Size(98, 24);
             this.UninstallButton.TabIndex = 2;
             this.UninstallButton.Text = "Uninstall";
             this.toolTip1.SetToolTip(this.UninstallButton, "Uninjects ED and prompts you to delete ED\'s files.");
@@ -98,10 +101,11 @@
             this.UpdateButton.Enabled = false;
             this.UpdateButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.UpdateButton.Font = new System.Drawing.Font("Consolas", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.UpdateButton.ForeColor = System.Drawing.Color.Yellow;
-            this.UpdateButton.Location = new System.Drawing.Point(155, 199);
+            this.UpdateButton.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.UpdateButton.Location = new System.Drawing.Point(116, 162);
+            this.UpdateButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.UpdateButton.Name = "UpdateButton";
-            this.UpdateButton.Size = new System.Drawing.Size(130, 30);
+            this.UpdateButton.Size = new System.Drawing.Size(98, 24);
             this.UpdateButton.TabIndex = 3;
             this.UpdateButton.Text = "Update";
             this.toolTip1.SetToolTip(this.UpdateButton, "Replaces the ED files with the most recent ones [Coming Soon™]");
@@ -109,9 +113,10 @@
             // 
             // InstallProgress
             // 
-            this.InstallProgress.Location = new System.Drawing.Point(12, 218);
+            this.InstallProgress.Location = new System.Drawing.Point(9, 177);
+            this.InstallProgress.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.InstallProgress.Name = "InstallProgress";
-            this.InstallProgress.Size = new System.Drawing.Size(415, 23);
+            this.InstallProgress.Size = new System.Drawing.Size(311, 19);
             this.InstallProgress.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
             this.InstallProgress.TabIndex = 5;
             this.InstallProgress.Visible = false;
@@ -120,10 +125,11 @@
             // 
             this.StatusLabel2.AutoSize = true;
             this.StatusLabel2.Font = new System.Drawing.Font("Consolas", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.StatusLabel2.ForeColor = System.Drawing.Color.Orange;
-            this.StatusLabel2.Location = new System.Drawing.Point(9, 190);
+            this.StatusLabel2.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.StatusLabel2.Location = new System.Drawing.Point(7, 154);
+            this.StatusLabel2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.StatusLabel2.Name = "StatusLabel2";
-            this.StatusLabel2.Size = new System.Drawing.Size(96, 17);
+            this.StatusLabel2.Size = new System.Drawing.Size(73, 13);
             this.StatusLabel2.TabIndex = 8;
             this.StatusLabel2.Text = "Lorem ipsum";
             this.StatusLabel2.Visible = false;
@@ -132,10 +138,11 @@
             // 
             this.StatusLabel.AutoSize = true;
             this.StatusLabel.Font = new System.Drawing.Font("Consolas", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.StatusLabel.ForeColor = System.Drawing.Color.Orange;
-            this.StatusLabel.Location = new System.Drawing.Point(8, 167);
+            this.StatusLabel.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.StatusLabel.Location = new System.Drawing.Point(6, 136);
+            this.StatusLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.StatusLabel.Name = "StatusLabel";
-            this.StatusLabel.Size = new System.Drawing.Size(230, 23);
+            this.StatusLabel.Size = new System.Drawing.Size(189, 19);
             this.StatusLabel.TabIndex = 9;
             this.StatusLabel.Text = "Installation failed.";
             this.StatusLabel.Visible = false;
@@ -144,10 +151,11 @@
             // 
             this.StatusCloseButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.StatusCloseButton.Font = new System.Drawing.Font("Consolas", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.StatusCloseButton.ForeColor = System.Drawing.Color.Orange;
-            this.StatusCloseButton.Location = new System.Drawing.Point(363, 182);
+            this.StatusCloseButton.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.StatusCloseButton.Location = new System.Drawing.Point(142, 102);
+            this.StatusCloseButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.StatusCloseButton.Name = "StatusCloseButton";
-            this.StatusCloseButton.Size = new System.Drawing.Size(64, 30);
+            this.StatusCloseButton.Size = new System.Drawing.Size(48, 24);
             this.StatusCloseButton.TabIndex = 10;
             this.StatusCloseButton.Text = "Close";
             this.StatusCloseButton.UseVisualStyleBackColor = true;
@@ -156,15 +164,16 @@
             // 
             // StatusText
             // 
-            this.StatusText.BackColor = System.Drawing.Color.DarkRed;
+            this.StatusText.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(31)))), ((int)(((byte)(36)))), ((int)(((byte)(36)))));
             this.StatusText.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.StatusText.Font = new System.Drawing.Font("Consolas", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.StatusText.ForeColor = System.Drawing.Color.Gold;
-            this.StatusText.Location = new System.Drawing.Point(11, 68);
+            this.StatusText.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.StatusText.Location = new System.Drawing.Point(8, 55);
+            this.StatusText.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.StatusText.Multiline = true;
             this.StatusText.Name = "StatusText";
             this.StatusText.ReadOnly = true;
-            this.StatusText.Size = new System.Drawing.Size(416, 48);
+            this.StatusText.Size = new System.Drawing.Size(312, 39);
             this.StatusText.TabIndex = 11;
             this.StatusText.Text = "Make sure to launch Discord before installing!";
             this.StatusText.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
@@ -177,10 +186,11 @@
             this.DevButton.ForeColor = System.Drawing.Color.White;
             this.DevButton.Image = global::EnhancedDiscordUI.Properties.Resources.discord_dev_64;
             this.DevButton.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.DevButton.Location = new System.Drawing.Point(320, 98);
+            this.DevButton.Location = new System.Drawing.Point(240, 80);
+            this.DevButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.DevButton.Name = "DevButton";
             this.DevButton.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.DevButton.Size = new System.Drawing.Size(90, 109);
+            this.DevButton.Size = new System.Drawing.Size(68, 89);
             this.DevButton.TabIndex = 15;
             this.DevButton.Text = "Dev";
             this.DevButton.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -197,10 +207,11 @@
             this.CanaryButton.ForeColor = System.Drawing.Color.Gold;
             this.CanaryButton.Image = global::EnhancedDiscordUI.Properties.Resources.discord_canary_64;
             this.CanaryButton.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.CanaryButton.Location = new System.Drawing.Point(224, 98);
+            this.CanaryButton.Location = new System.Drawing.Point(168, 80);
+            this.CanaryButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.CanaryButton.Name = "CanaryButton";
             this.CanaryButton.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.CanaryButton.Size = new System.Drawing.Size(90, 109);
+            this.CanaryButton.Size = new System.Drawing.Size(68, 89);
             this.CanaryButton.TabIndex = 14;
             this.CanaryButton.Text = "Canary";
             this.CanaryButton.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -217,10 +228,11 @@
             this.PTBButton.ForeColor = System.Drawing.Color.SteelBlue;
             this.PTBButton.Image = global::EnhancedDiscordUI.Properties.Resources.discord_stable_64;
             this.PTBButton.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.PTBButton.Location = new System.Drawing.Point(128, 98);
+            this.PTBButton.Location = new System.Drawing.Point(96, 80);
+            this.PTBButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.PTBButton.Name = "PTBButton";
             this.PTBButton.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.PTBButton.Size = new System.Drawing.Size(90, 109);
+            this.PTBButton.Size = new System.Drawing.Size(68, 89);
             this.PTBButton.TabIndex = 13;
             this.PTBButton.Text = "PTB";
             this.PTBButton.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -237,10 +249,11 @@
             this.StableButton.ForeColor = System.Drawing.Color.SteelBlue;
             this.StableButton.Image = global::EnhancedDiscordUI.Properties.Resources.discord_stable_64;
             this.StableButton.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.StableButton.Location = new System.Drawing.Point(32, 98);
+            this.StableButton.Location = new System.Drawing.Point(24, 80);
+            this.StableButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.StableButton.Name = "StableButton";
             this.StableButton.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.StableButton.Size = new System.Drawing.Size(90, 109);
+            this.StableButton.Size = new System.Drawing.Size(68, 89);
             this.StableButton.TabIndex = 12;
             this.StableButton.Text = "Stable";
             this.StableButton.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -252,9 +265,10 @@
             // pictureBox1
             // 
             this.pictureBox1.Image = global::EnhancedDiscordUI.Properties.Resources.ed_og;
-            this.pictureBox1.Location = new System.Drawing.Point(41, 12);
+            this.pictureBox1.Location = new System.Drawing.Point(31, 10);
+            this.pictureBox1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(87, 50);
+            this.pictureBox1.Size = new System.Drawing.Size(65, 41);
             this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.pictureBox1.TabIndex = 4;
             this.pictureBox1.TabStop = false;
@@ -263,10 +277,11 @@
             // 
             this.OpenFolderButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.OpenFolderButton.Font = new System.Drawing.Font("Consolas", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.OpenFolderButton.ForeColor = System.Drawing.Color.Orange;
-            this.OpenFolderButton.Location = new System.Drawing.Point(301, 146);
+            this.OpenFolderButton.ForeColor = System.Drawing.Color.WhiteSmoke;
+            this.OpenFolderButton.Location = new System.Drawing.Point(116, 70);
+            this.OpenFolderButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.OpenFolderButton.Name = "OpenFolderButton";
-            this.OpenFolderButton.Size = new System.Drawing.Size(126, 30);
+            this.OpenFolderButton.Size = new System.Drawing.Size(94, 24);
             this.OpenFolderButton.TabIndex = 16;
             this.OpenFolderButton.Text = "Open Folder";
             this.OpenFolderButton.UseVisualStyleBackColor = true;
@@ -275,27 +290,28 @@
             // 
             // EDInstaller
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.BackColor = System.Drawing.Color.DarkRed;
-            this.ClientSize = new System.Drawing.Size(439, 253);
-            this.Controls.Add(this.DevButton);
-            this.Controls.Add(this.CanaryButton);
-            this.Controls.Add(this.PTBButton);
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(31)))), ((int)(((byte)(36)))), ((int)(((byte)(36)))));
+            this.ClientSize = new System.Drawing.Size(329, 206);
             this.Controls.Add(this.StableButton);
-            this.Controls.Add(this.StatusText);
+            this.Controls.Add(this.PTBButton);
+            this.Controls.Add(this.CanaryButton);
+            this.Controls.Add(this.DevButton);
+            this.Controls.Add(this.UninstallButton);
             this.Controls.Add(this.StatusCloseButton);
             this.Controls.Add(this.StatusLabel);
             this.Controls.Add(this.StatusLabel2);
             this.Controls.Add(this.InstallProgress);
             this.Controls.Add(this.pictureBox1);
             this.Controls.Add(this.UpdateButton);
-            this.Controls.Add(this.UninstallButton);
             this.Controls.Add(this.Title);
             this.Controls.Add(this.InstallButton);
             this.Controls.Add(this.OpenFolderButton);
+            this.Controls.Add(this.StatusText);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.Name = "EDInstaller";
             this.Text = "EnhancedDiscord Installer";
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();

--- a/installer/EnhancedDiscordUI/Form1.cs
+++ b/installer/EnhancedDiscordUI/Form1.cs
@@ -41,7 +41,7 @@ namespace EnhancedDiscordUI
             UpdateButton.Hide();
             StatusText.Hide();
             StatusLabel.Show();
-            StatusLabel.Text = (operation == "UNINSTALL" ? "Unin" : "In") + "stallation " + (failed ? " failed." : "completed!");
+            StatusLabel.Text = operation == "UPDATE" ? "Update " + (failed ? "failed" : "complete") : (operation == "UNINSTALL" ? "Unin" : "In") + "stallation " + (failed ? " failed." : "completed!");
             StatusLabel.ForeColor = failed ? Color.Red : Color.Lime;
             StatusLabel2.Show();
             StatusLabel2.Text = reason;
@@ -295,7 +295,7 @@ namespace EnhancedDiscordUI
                 DialogResult confirmResult = MessageBox.Show("ED folder already exists. Overwrite it?", "EnhancedDiscord - Confirm Overwrite", MessageBoxButtons.YesNo);
                 if (confirmResult == DialogResult.No)
                 {
-                    endInstallation("Not replacing old ED files.", false); return;
+                    endInstallation("Not replacing old ED files, restart Discord manually.", false); return;
                 }
                 try
                 {
@@ -493,6 +493,161 @@ namespace EnhancedDiscordUI
             {
                 startDetached("open", "./EnhancedDiscord");
             }
+        }
+
+        async private void UpdateButton_Click(object sender, EventArgs e)
+        {
+            operation = "UPDATE";
+            InstallButton.Hide();
+            UninstallButton.Hide();
+            UpdateButton.Hide();
+            StatusText.Show();
+            InstallProgress.Show();
+            InstallProgress.Value = 0;
+       
+            string tempPath = Path.Combine(Path.GetTempPath(), "EnhancedDiscord");
+            if (Directory.Exists(tempPath))
+            {
+                try
+                {
+                    Directory.Delete(tempPath, true);
+                }
+                catch
+                {
+                    StatusText.Text = "Error deleting temp folders.";
+                }
+            }
+            Directory.CreateDirectory(tempPath);
+
+            StatusText.Text = "Downloading package...";
+            string zipPath = Path.Combine(tempPath, "EnhancedDiscord.zip");
+            string zipLink = Properties.Resources.zipLink + Properties.Resources.branch;
+            WebClient wc = new WebClient();
+            try
+            {
+                await wc.DownloadFileTaskAsync(new Uri(zipLink), zipPath);
+            }
+            catch (Exception err)
+            {
+                Debug.Write(err);
+                endInstallation("Failed to download ED files.", true); return;
+            }
+            InstallProgress.Value = 40;
+            StatusText.Text = "Successfully downloaded. Extracting...";
+
+            try
+            {
+                ZipFile.ExtractToDirectory(zipPath, tempPath);
+            }
+            catch (Exception err)
+            {
+                Debug.Write(err);
+                endInstallation("Failed to extract zip file.", true); return;
+            }
+            InstallProgress.Value = 50;
+            StatusText.Text = "Finished extracting zip. Checking core...";
+
+            string extractedPath = Path.Combine(tempPath, "EnhancedDiscord-" + Properties.Resources.branch);
+            string enhancedPath = "./EnhancedDiscord";
+
+            if (!File.Exists(Path.Combine(enhancedPath, "config.json")))
+            {
+                try
+                {
+                    File.WriteAllText(Path.Combine(enhancedPath, "config.json"), "{}");
+                }
+                catch
+                {
+                }
+            }
+
+            string[] garbage = new string[] { "theme.css", "README.md", "plugins.md", ".gitignore", "advanced_installation.md" };
+            foreach (string file in Directory.GetFiles(extractedPath))
+            {
+                string filename = Path.GetFileName(file);
+                if (Array.Exists(garbage, f => f == filename)) continue;
+                string equiv = Path.Combine(enhancedPath, filename);
+                bool filesEqual = false;
+                bool fileExists = File.Exists(equiv);
+                if (fileExists) filesEqual = FilesEqual(file, equiv);
+                try
+                {
+                    if (fileExists && !filesEqual) File.Delete(equiv);
+                    if (!fileExists || !filesEqual) File.Copy(file, equiv);
+                }
+                catch (Exception err)
+                {
+                    Debug.Write(err);
+                    StatusText.Text = "Could not update plugin: " + filename;
+                }
+            }
+            InstallProgress.Value = 70;
+            StatusText.Text = "Core finished. Checking plugins...";
+
+            string pluginPath = Path.Combine(enhancedPath, "plugins");
+            if (!Directory.Exists(pluginPath)) Directory.CreateDirectory(pluginPath);
+            foreach (string file in Directory.GetFiles(Path.Combine(extractedPath, "plugins")))
+            {
+                string filename = Path.GetFileName(file);
+                string equiv = Path.Combine(pluginPath, filename);
+                bool filesEqual = false;
+                bool fileExists = File.Exists(equiv);
+                if (fileExists) filesEqual = FilesEqual(file, equiv);
+                try
+                {
+                    if (fileExists && !filesEqual) File.Delete(equiv);
+                    if (!fileExists || !filesEqual) File.Copy(file, equiv);
+                }
+                catch (Exception err)
+                {
+                    Debug.Write(err);
+                    StatusText.Text = "Could not update plugin: " + filename;
+                }
+            }
+
+            StatusText.Text = "Cleaning up...";
+            if (Directory.Exists(tempPath))
+            {
+                try
+                {
+                    Directory.Delete(tempPath, true);
+                }
+                catch
+                {
+                    StatusText.Text = "Error deleting temp folders.";
+                }
+            }
+            InstallProgress.Value = 90;
+            endInstallation("ED files updated.", false); return;
+        }
+
+        // Adapted from https://stackoverflow.com/questions/7931304/comparing-two-files-in-c-sharp
+        private bool FilesEqual(string filename1, string filename2)
+        {
+            if (filename1 == filename2) return true;
+
+            FileStream fileStream1 = new FileStream(filename1, FileMode.Open, FileAccess.Read);
+            FileStream fileStream2 = new FileStream(filename2, FileMode.Open, FileAccess.Read);
+            if (fileStream1.Length != fileStream2.Length)
+            {
+                fileStream1.Close();
+                fileStream2.Close();
+                return false;
+            }
+
+            int fileByte1;
+            int fileByte2;
+            do
+            {
+                fileByte1 = fileStream1.ReadByte();
+                fileByte2 = fileStream2.ReadByte();
+            }
+            while ((fileByte1 == fileByte2) && (fileByte1 != -1));
+
+            fileStream1.Close();
+            fileStream2.Close();
+
+            return ((fileByte1 - fileByte2) == 0);
         }
     }
 }

--- a/installer/EnhancedDiscordUI/Form1.cs
+++ b/installer/EnhancedDiscordUI/Form1.cs
@@ -42,6 +42,7 @@ namespace EnhancedDiscordUI
             StatusText.Hide();
             StatusLabel.Show();
             StatusLabel.Text = (operation == "UNINSTALL" ? "Unin" : "In") + "stallation " + (failed ? " failed." : "completed!");
+            StatusLabel.ForeColor = failed ? Color.Red : Color.Lime;
             StatusLabel2.Show();
             StatusLabel2.Text = reason;
             StatusCloseButton.Show();


### PR DESCRIPTION
Fixes the CSP issues for importing the theme and any images by allowing `https` to bypass it. This means the CSP still protects from some XSS attacks like inline js (non-nonced) and things like `eval`.

The installer was given a slight restyle to prevent overlapping of some buttons and labels as well as changing up the color scheme to be less jarring to the eyes (and to match the site better). The final success/failure label also now changes to green or red to represent the result.

Update functionality was added to the installer. This function grabs the zip from github then checks if the ED files currently in the folder match up with the most recent from github (on a file-by-file basis) and replace the old ones if they are different. The advantage to this over the install of course being that other files (like non-core ED plugins) are preserved instead of being deleted while still allowing core ED and core ED plugins to be updated.