### PR TITLE
Adjust plugin loading for discord changes

### DIFF
--- a/dom_shit.js
+++ b/dom_shit.js
@@ -165,6 +165,9 @@ process.once("loaded", async () => {
     if (window.ED.config.antiTrack !== false)
         window.monkeyPatch(window.findModule('track'), 'track', () => {});
 	
+    while (Object.keys(window.req.c).length < 5000)
+        await c.sleep(1000); // wait until most modules are loaded for plugins
+	
 	    //load and validate plugins
     let pluginFiles = fs.readdirSync(path.join(process.env.injDir, 'plugins'));
     let plugins = {};


### PR DESCRIPTION
Last time we wanted to allow plugins to use `findModule` at any point but discord changed their loading scheme again so plugins couldn't grab the module when they started. (This includes my ED exclusive plugin ReadAll)

So this change looks for about 5000 modules to be loaded in, which should be sufficient (there are about 5600 total but a lot of the last ones are empty, utility functions that aren't so useful to us (like summing an array) or some weird components I couldn't find actually used). These should be loaded in by the time reading the plugin files completes anyways.