### PR TITLE
Fix for electron 3.x.x (Discord Canary)

### DIFF
--- a/installer/EnhancedDiscordUI/Properties/Resources.resx
+++ b/installer/EnhancedDiscordUI/Properties/Resources.resx
@@ -149,7 +149,7 @@
     <value>..\Resources\ed_og.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="injection" xml:space="preserve">
-    <value>const { BrowserWindow, session } = require('electron');
+    <value>const { BrowserWindow: OriginalBrowserWindow, session } = require('electron');
 const path = require('path');
 
 session.defaultSession.webRequest.onHeadersReceived(function(details, callback) {
@@ -163,7 +163,7 @@ session.defaultSession.webRequest.onHeadersReceived(function(details, callback) 
 ;
 });
 
-class PatchedBrowserWindow extends BrowserWindow {
+class BrowserWindow extends OriginalBrowserWindow {
     constructor(originalOptions) {
         const options = Object.create(originalOptions);
         options.webPreferences = Object.create(options.webPreferences);
@@ -182,7 +182,7 @@ class PatchedBrowserWindow extends BrowserWindow {
 
 const electron_path = require.resolve('electron');
 const browser_window_path = require.resolve(path.resolve(electron_path, '..', '..', 'browser-window.js'));
-require.cache[browser_window_path].exports = PatchedBrowserWindow;</value>
+require.cache[browser_window_path].exports = BrowserWindow;</value>
   </data>
   <data name="zipLink" xml:space="preserve">
     <value>https://codeload.github.com/joe27g/EnhancedDiscord/zip/</value>


### PR DESCRIPTION
The new BrowserWindow object in 3.0.0+ has checks now to see if it is a BrowserWindow using this function:
```js
const isBrowserWindow = (win) => {
  return win && win.constructor.name === 'BrowserWindow'
}
```
So this patch just ensures the object is still named properly. Without this it has several errors on startup, ED fails to load, and devtools cannot be opened.

Note: This of course will require a rebuild of the installer and reupload to the site