### PR TITLE
Fix process.env.injDir being undefined [Linux Only] (dom_shit.js)

### DIFF
--- a/dom_shit.js
+++ b/dom_shit.js
@@ -4,6 +4,9 @@ const electron = window.require('electron');
 const currentWindow = electron.remote.getCurrentWindow();
 if (currentWindow.__preload) require(currentWindow.__preload);
 
+//Get inject directory
+process.env.injDir = __dirname;
+
 //set up global functions
 let c = {
     log: function(msg, plugin) {

--- a/dom_shit.js
+++ b/dom_shit.js
@@ -5,7 +5,7 @@ const currentWindow = electron.remote.getCurrentWindow();
 if (currentWindow.__preload) require(currentWindow.__preload);
 
 //Get inject directory
-process.env.injDir = __dirname;
+if (!process.env.injDir) process.env.injDir = __dirname;
 
 //set up global functions
 let c = {


### PR DESCRIPTION
For some reason process.env.injDir was undefined even when being set during manual installation. This fix makes process.env.injDir the directory which the script is in (Which should always be the correct directory)