### PR TITLE
Let's try this again, shall we; fixed settings tabs from not unclicking (#4)

### DIFF
--- a/plugins/ed_settings.js
+++ b/plugins/ed_settings.js
@@ -82,12 +82,10 @@ module.exports = new Plugin({
                 settingsTab.parentNode.insertBefore(sep, settingsTab.nextSibling);
 
                 parent.onclick = function(e) {
-                    if (!e.target.className || e.target.className.indexOf(tabsM.itemDefault) == -1) return;
-                    //console.log(e.target);
+                    if (!e.target.className || (e.target.className === tabsM.itemDefault || e.target.className.indexOf(tabsM.itemDefault) > -1)) return;
 
                     for (let i in tab) {
                         tab[i].className = (tab[i].className || '')
-                            //.replace(tabsM.selected, tabsM.notSelected)
                             .replace(tabsM.itemSelected, tabsM.itemDefault)
                     };
                 }


### PR DESCRIPTION
Prevents ED settings from being marked as selected when switching to a new tab thus closing issue #4. 

**Note**: Navigating to the last, or should I say the previous tab (excluding 'Plugins' and 'Settings') is still an on-going issue. You can read up on that [here]( https://github.com/joe27g/EnhancedDiscord/issues/4#issuecomment-410553951).