### PR TITLE
[Hidden Channels] New UI when click on hidden channels.

### DIFF
--- a/plugins/hidden_channels.js
+++ b/plugins/hidden_channels.js
@@ -193,9 +193,7 @@ module.exports = new Plugin({
             if (m.toolbar && m.selected) return m;
         }).toolbar);
 
-        toolbar.children[0].remove(); // Remove channel specific actions (e.g. pinned msgs, mute)
-        toolbar.children[1].remove(); // @TODO Pinned messages icon is a bitch bitch and won't remove ?
-        toolbar.children[2].remove(); // Remove ability to hide user list as it will crash Discord when the notice is up.
+        toolbar.style.display = "none";
 
 
         const hiddenChannelNotif = document.createElement("div");

--- a/plugins/hidden_channels.js
+++ b/plugins/hidden_channels.js
@@ -208,7 +208,7 @@ module.exports = new Plugin({
         hiddenChannelNotif.innerHTML = `
         <div class="${flx.flex} ${flx.directionColumn} ${flx.alignCenter}">
         <h2 class="${txt.h2} ${txt.defaultColor}">This is a hidden channel.</h2>
-        <h5 class="${txt.h5} ${txt.defaultColor}">You cannot see the contents of this channel however you may see it's name and topic.</h5>
+        <h5 class="${txt.h5} ${txt.defaultColor}">You cannot see the contents of this channel. However, you may see its name and topic.</h5>
         </div>
         `
 

--- a/plugins/hidden_channels.js
+++ b/plugins/hidden_channels.js
@@ -144,6 +144,13 @@ module.exports = new Plugin({
                 return false; // don't show icon on hidden channel pins.
             return b.callOriginalMethod(b.methodArguments);
         });
+
+        findModule("dispatch").subscribe("CHANNEL_SELECT", module.exports.dispatchSubscription);
+
+        monkeyPatch(findModule("fetchMessages"), "fetchMessages", function(d) {
+            if (window.ED._hiddenChans.includes(d.methodArguments[0])) return;
+            else return d.callOriginalMethod();
+        })
     },
 
     unload: function() {
@@ -151,6 +158,9 @@ module.exports = new Plugin({
         if (m.__monkeyPatched && m.unpatch)
             m.unpatch();
         m = findModule('hasUnread').__proto__.hasUnreadPins;
+        if (m.__monkeyPatched && m.unpatch)
+            m.unpatch();
+        m = findModule('fetchMessages').fetchMessages;
         if (m.__monkeyPatched && m.unpatch)
             m.unpatch();
         m = findModule('computePermissions');
@@ -161,5 +171,49 @@ module.exports = new Plugin({
             if (mod && mod.__monkeyPatched && mod.unpatch)
                 mod.unpatch();
         }
+
+        findModule("dispatch").unsubscribe("CHANNEL_SELECT", module.exports.dispatchSubscription);
+    },
+    dispatchSubscription: function (data) {
+        if (data.type !== "CHANNEL_SELECT") return;
+
+        if (ED._hiddenChans.includes(data.channelId)) {
+            setTimeout(module.exports.attachHiddenChanNotice,100); // This value could be brought down however I don't know if lower spec users would suffer.
+        }
+    },
+    attachHiddenChanNotice: function () {
+        const messagesWrapper = document.querySelector(`.${findModule("messages").messagesWrapper}`);
+
+        messagesWrapper.firstChild.remove(); // Remove messages shit.
+        messagesWrapper.parentElement.children[1].remove(); // Remove message box.
+        messagesWrapper.parentElement.parentElement.children[1].remove(); // Remove user list.
+
+        const toolbar = document.querySelector("."+EDApi.findModule(m => {
+            if (m instanceof Window) return;
+            if (m.toolbar && m.selected) return m;
+        }).toolbar);
+
+        toolbar.children[0].remove(); // Remove channel specific actions (e.g. pinned msgs, mute)
+        toolbar.children[1].remove(); // @TODO Pinned messages icon is a bitch bitch and won't remove ?
+        toolbar.children[2].remove(); // Remove ability to hide user list as it will crash Discord when the notice is up.
+
+
+        const hiddenChannelNotif = document.createElement("div");
+        
+        // Class name modules
+        const txt = findModule("h5");
+        const flx = findModule("flex");
+
+        hiddenChannelNotif.className = flx.flexCenter; // yikes american spelling
+        hiddenChannelNotif.style.width = "100%";
+
+        hiddenChannelNotif.innerHTML = `
+        <div class="${flx.flex} ${flx.directionColumn} ${flx.alignCenter}">
+        <h2 class="${txt.h2} ${txt.defaultColor}">This is a hidden channel.</h2>
+        <h5 class="${txt.h5} ${txt.defaultColor}">You cannot see the contents of this channel however you may see it's name and topic.</h5>
+        </div>
+        `
+
+        messagesWrapper.appendChild(hiddenChannelNotif);
     }
 });


### PR DESCRIPTION
New UI when a user clicks on a hidden channel powered via a dispatch subscription.

Preview:

![Discord_2019-07-02_00-45-26](https://user-images.githubusercontent.com/34782021/60472902-b3df6180-9c62-11e9-84db-4308851e3606.png)


The `fetchMessages` function has been monkeyPatched to avoid unnecessary API calls.

Also, could any try and lower the delay found on line 181 especially lower spec users? 
~~Also2: If anyone knows how to stop the pinned badge from reappearing after a `Node.remove()` call that would be greatly appreciated.~~ Edit: found ez method, see [this](https://github.com/joe27g/EnhancedDiscord/pull/84/commits/e40f5a9a0b358f0bd88dcd124e82f74b90793eca)