### PR TITLE
Prevent dom_shit.js from injecting too soon

### DIFF
--- a/dom_shit.js
+++ b/dom_shit.js
@@ -93,7 +93,7 @@ window.ED.localStorage = window.localStorage;
 
 process.once("loaded", async () => {
     c.log(`Loading v${window.ED.version}...`);
-	while (typeof window.webpackJsonp === 'undefined')
+	while (!window.webpackJsonp || window.webpackJsonp.length < 25)
 		await c.sleep(1000); // wait until this is loaded in order to use it for modules
 
     window.ED.webSocket = window._ws;


### PR DESCRIPTION
Fix by .intrnl on the Discord server. Without this, many plugins will fail to load properly. Doesn't seem to have anything to do with my connection, so it's probably hardware-related.