### PR TITLE
One small step for man. One giant leap for mankind.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ By default, this loads my theme, with some settings applied. More info [on its r
 You can download more quality plugins from the following repos:
 - [joe27g/EnhancedDiscord-Plugins](https://github.com/joe27g/EnhancedDiscord-Plugins)
 - [rauenzi/EnhancedDiscordPlugins](https://github.com/rauenzi/EnhancedDiscordPlugins)
-- [jakuski/ed_plugins](https://github.com/jakuski/ed_plugins)
+- [jakuski/ed_plugins](https://github.com/jakuski/ed_plugins) (These are deprecated and most do not work, however you can use these as a guide to creating your own plugins).
 
 If you enable "BD Plugins" in the EnhancedDiscord settings, you can also load BetterDiscord plugins. See the #faq in the support server for more details.
 *Note: some BD plugins are notorious for being laggy. In general, the fewer plugins you have, the faster your client will be.*

--- a/dom_shit.js
+++ b/dom_shit.js
@@ -38,7 +38,7 @@ const c = {
     }
 }
 // config util
-window.ED = { plugins: {}, version: '2.6.2' };
+window.ED = { plugins: {}, version: '2.7.0' };
 Object.defineProperty(window.ED, 'config', {
     get: function() {
         let conf;

--- a/plugins.md
+++ b/plugins.md
@@ -77,18 +77,9 @@ You can also add your own section to EnhancedDiscord's settings in your plugin, 
 
 * **You must have a `config` for the following to work.** Set it to an empty object if you do not need it.
 
-* `generateSettings`: a function that is called when EnhancedDiscord settings are opened. This should return HTML to be placed in your setttings section.
-
-* `settingListeners`: an Object mapping selectors to eventlisteners.
-   * For example, if your `generateSettings` function has an element `<input type="checkbox" id="memez">`, you might use the following format:
-   ```js
-   settingListeners: [{
-		el: '#memez',
-		type: 'click'
-		eHandler: function() {
-			alert('some dumb text');
-		}
-   }]
-   ```
-
-#### For more examples, just browse the included plugins, namely `emoji_packs`.
+* `generateSettings`: a function that is called when EnhancedDiscord settings are opened. This should return any of the following:
+	* `DOMString` A HTML string paired with a `plugin.settingsListeners` property.
+	*  _`instanceof`_`HTMLElement` The value returned by any call to `document.createElement(...)`, you can modify this class before returning it, e.g. setting inner children by `HTMLElement.appendChild`
+	* `ReactNode` Any valid react element. **Make sure you call call React.createElement on your component**, if you return a function or a class this will not work.
+	* `DiscordUIElement[]` An array of elements for the ED's Discord UI generator to create. See the link below for more information
+	* ***[Click here for more information on creating settings user interface within EnhancedDiscord](https://gist.github.com/jakuski/995ae48530f3527285f4c23c3de74237)***

--- a/plugins/ed_settings.js
+++ b/plugins/ed_settings.js
@@ -101,8 +101,13 @@ module.exports = new Plugin({
 
 		*/
 		return [{
-			section: "HEADER",
-			label: "EnhancedDiscord"
+			section: "CUSTOM",
+			element: () => {
+				const { join } = module.exports.utils;
+				const { header } = findModule("topPill");
+
+				return EDApi.React.createElement("div", { className: join(header, "ed-settings") }, "EnhancedDiscord")
+			}
 		},{
 			section: "ED/Plugins",
 			label: "Plugins",

--- a/plugins/ed_settings.js
+++ b/plugins/ed_settings.js
@@ -4,7 +4,20 @@ const getComponentFromFluxContainer = component => {
 	return (new component({})).render().type
 }
 
-const getReact = () => window.req.c[0].exports.createElement;
+const getReact = (returnEntireReact = false) => { // WHY. THE. FUCK. https://github.com/joe27g/EnhancedDiscord/commit/976849e47fd0bd72af8e503bf2a593194bab2051
+	const React = window.req.c[0].exports
+	return returnEntireReact ? React : React.createElement;
+}
+
+const join = (...args) => args.join(" ");
+
+const get = moduleName => {
+	switch(moduleName) {
+		case "animated": return findModule("createAnimatedComponent");
+		case "react": return findModule("createElement");
+		case "react-ce": return findModule("createElement").createElement;
+	}
+}
 
 const EDSettings = {
 	name: 'ED Settings (React)',
@@ -27,6 +40,7 @@ const EDSettings = {
 		
 		this._initClassMaps(window.ED.classMaps);
 		this._initDiscordComponents(window.ED.discordComponents);
+		this._noticeStore = new this.NoticeStoreMimic();
 		this.settingsSections = this._getDefaultSections(); // Easily allow plugins to add in their own sections if need be.
 
 		this.unpatch = EDApi.monkeyPatch(
@@ -63,9 +77,14 @@ const EDSettings = {
 		normal sections / pages
 			section: [string] an id string of some sort, must be unique.
 			label: [string] self-explanatory
-			element: [react-renderable (either a funuction or a class)] the page that will be rendered on the right when the section is clicked
+			element: [optional] [react-renderable] the page that will be rendered on the right when the section is clicked
 			color: [optional] [string (hex)] a colour to be applied to the section (see the log out / discord nitro btn)
 			onClick: [optional] [function] a function to be executed whenever the element is clicked
+			notice: [notice-obj (see below)] object to determine whether to have notices (like the careful you have unsaved changes popups)
+
+			notice-obj
+				element: [react-renderable]
+				store: [redux store | NoticeStoreMimic] store that the setin
 
 		special sections
 			headers
@@ -76,8 +95,9 @@ const EDSettings = {
 			custom element
 				section: "CUSTOM"
 				element: [react-renderable]
-
-		All sections regardless of type can have a optional .predicate property which should be a fn returning a boolean as to whether to show the section or not
+		
+		all sections regardless of type can have the following
+			predicate: [function => boolean] determine whether the section should be shown
 
 		*/
 		return [{
@@ -90,7 +110,11 @@ const EDSettings = {
 		},{
 			section: "ED/Settings",
 			label: "Settings",
-			element: this.components.SettingsPage
+			element: this.components.SettingsPage,
+			notice: {
+				element: this.components.Notice,
+				store: this._noticeStore
+			}
 		},{
 			section: "DIVIDER"
 		}];
@@ -104,7 +128,9 @@ const EDSettings = {
         obj.buttons = EDApi.findModule('lookFilled');
         obj.switchItem = EDApi.findModule('switchItem');
         obj.alignment = EDApi.findModule('horizontalReverse');
-        obj.description = EDApi.findModule('formText');
+		obj.description = EDApi.findModule('formText');
+		// New
+		obj.shadows = findModule("elevationHigh");
 	},
 	_initDiscordComponents(obj) {
 		const e = getReact(); 
@@ -115,11 +141,14 @@ const EDSettings = {
 		obj.RadioGroup = EDApi.findModuleByDisplayName("RadioGroup");
 		obj.Title = EDApi.findModuleByDisplayName("FormTitle");
 		obj.Text = EDApi.findModuleByDisplayName("FormText");
+		obj.FormSection = EDApi.findModuleByDisplayName("FormSection");
 		obj.Icon = EDApi.findModuleByDisplayName("Icon");
 		obj.LoadingSpinner = EDApi.findModuleByDisplayName("Spinner");
 		obj.Card = EDApi.findModuleByDisplayName("FormNotice");
 		obj.Flex = EDApi.findModuleByDisplayName("Flex");
 		obj.Switch = EDApi.findModuleByDisplayName("Switch");
+		obj.SwitchItem = EDApi.findModuleByDisplayName("SwitchItem");
+		obj.Button = findModule("Sizes");
 		
 		obj.Divider = props => {
 			props.className = props.className ? props.className + " " + ED.classMaps.divider : ED.classMaps.divider
@@ -128,15 +157,65 @@ const EDSettings = {
 	},
 	components: {
 		PluginsPage () {
-			const e = getReact(); 
-			return e("div")
+			const e = getReact();
+			const { FormSection, Divider } = ED.discordComponents;
+
+
+			return e(FormSection, {title: "EnhancedDiscord Plugins", tag: "h2"},
+				e(EDSettings.components.OpenPluginDirBtn),
+				e(Divider, {className: join(ED.classMaps.margins.marginTop20, ED.classMaps.margins.marginBottom20)})
+			)
 		},
 		SettingsPage () {
 			const e = getReact();
-			return e("div")
+			const { FormSection, SwitchItem } = ED.discordComponents;
+
+			return e(FormSection, {title: "EnhancedDiscord Settings", tag: "h2"},
+				e(SwitchItem, {note: "Allows EnhancedDiscord to load BetterDiscord plugins natively. Reload (ctrl+r) for changes to take effect."}, "BetterDiscord Plugins")
+			)
 		},
 		Plugin () {
+			const e = getReact();
+			const { FormSection, SwitchItem } = ED.discordComponents;
 
+			return e("div", null, "xd")
+		},
+		BaseSettingsNotice (props) { // Component for other plugins to use
+			const e = getReact();
+			const noticeClassMap = findModule("resetButton");
+
+			return e("div", {className: noticeClassMap.container}, "xd")
+		},
+		OpenPluginDirBtn () {
+			const { createElement:e, useState } = getReact(true);
+			const { Button } = ED.discordComponents;
+			const [ string, setString ] = useState("Open Plugins Directory");
+
+			return e("div", null,
+				e(Button, {size: Button.Sizes.SMALL, color: Button.Colors.GREEN, onClick: () => {
+					console.log("dab")
+				}}, string));
+		}
+	},
+	NoticeStoreMimic: class { // Used to mimic a Redux? store for form notices.
+		constructor() {
+			this._cb = null;
+			this._shouldShowNotice = false;
+		}
+		/* To be used by the component */
+		setState(shouldShow) {
+			this._shouldShowNotice = shouldShow;
+			if (this._cb != null) this._cb();
+		}
+		/* Methods used by Discord */
+		showNotice() {
+			return this._shouldShowNotice;
+		}
+		addChangeListener(fn) {
+			this._cb = fn;
+		}
+		removeChangeListener() {
+			this._cb = null;
 		}
 	}
 }

--- a/plugins/ed_settings.js
+++ b/plugins/ed_settings.js
@@ -12,6 +12,11 @@ const EDSettings = {
     description: 'Adds an EnhancedDiscord tab in user settings.',
 	color: 'darkred',
 	async load () {
+		const discordConstants = EDApi.findModule("API_HOST");
+		const UserSettings = getComponentFromFluxContainer(
+			EDApi.findModule('getUserSettingsSections').default
+		);
+
         if (!window.ED.classMaps) {
             window.ED.classMaps = {};
 		}
@@ -20,32 +25,77 @@ const EDSettings = {
 			window.ED.discordComponents = {};
 		}
 		
-		this.initClassMaps(window.ED.classMaps);
-		this.initDiscordComponents(window.ED.discordComponents);
-
-		const UserSettings = getComponentFromFluxContainer(
-			EDApi.findModule('getUserSettingsSections').default
-		);
+		this._initClassMaps(window.ED.classMaps);
+		this._initDiscordComponents(window.ED.discordComponents);
+		this.settingsSections = this._getDefaultSections(); // Easily allow plugins to add in their own sections if need be.
 
 		this.unpatch = EDApi.monkeyPatch(
 			UserSettings.prototype,
 			"generateSections",
 			data => {
 				const sections = data.originalMethod.call(data.thisObject);
+				const devIndex = this._getDevIndex(sections, discordConstants);
 
-				sections.push({
-					section: "HEADER",
-					label: "YOU'RE GAY"
-				})
+				sections.splice(devIndex + 2, 0, ...this.settingsSections);
+
+				console.log(sections)
 
 				return sections;
 			}
 		)
 	},
 	unload () {
-		this.unpatch();
+		if (this.unpatch && typeof this.unpatch === "function") this.unpatch();
 	},
-	initClassMaps(obj) {
+	_getDevIndex(sections, constants) {
+		const indexOf = sections.indexOf(
+			sections.find(sect => sect.section === constants.UserSettingsSections.DEVELOPER_OPTIONS)
+		);
+
+		if (indexOf !== -1) return indexOf;
+		else return 28; // Hardcoded index fallback incase Discord mess with something
+	},
+	_getDefaultSections() {
+		/*
+
+		For future reference:
+
+		normal sections / pages
+			section: [string] an id string of some sort, must be unique.
+			label: [string] self-explanatory
+			element: [react-renderable (either a funuction or a class)] the page that will be rendered on the right when the section is clicked
+			color: [optional] [string (hex)] a colour to be applied to the section (see the log out / discord nitro btn)
+			onClick: [optional] [function] a function to be executed whenever the element is clicked
+
+		special sections
+			headers
+				section: "HEADER"
+				label: [string]
+			divider
+				section: "DIVIDER"
+			custom element
+				section: "CUSTOM"
+				element: [react-renderable]
+
+		All sections regardless of type can have a optional .predicate property which should be a fn returning a boolean as to whether to show the section or not
+
+		*/
+		return [{
+			section: "HEADER",
+			label: "EDR"
+		},{
+			section: "ED/Plugins",
+			label: "Plugins",
+			element: this.components.PluginsPage
+		},{
+			section: "ED/Settings",
+			label: "Settings",
+			element: this.components.SettingsPage
+		},{
+			section: "DIVIDER"
+		}];
+	},
+	_initClassMaps(obj) {
         const divM = EDApi.findModule(m => m.divider && Object.keys(m).length === 1)
         obj.headers = EDApi.findModule('defaultMarginh2');
         obj.margins = EDApi.findModule('marginBottom8');
@@ -56,21 +106,28 @@ const EDSettings = {
         obj.alignment = EDApi.findModule('horizontalReverse');
         obj.description = EDApi.findModule('formText');
 	},
-	initDiscordComponents(obj) {
-			obj.Textbox = EDApi.findModuleByDisplayName("TextInput"),
-			obj.Select = EDApi.findModuleByDisplayName("SelectTempWrapper"),
-			obj.Switch = EDApi.findModuleByDisplayName("SwitchItem"),
-			obj.RadioGroup = EDApi.findModuleByDisplayName("RadioGroup"),
-			obj.Divider = EDApi.findModuleByDisplayName("FormDivider"), // FIX
-			obj.Title = EDApi.findModuleByDisplayName("FormTitle"),
-			obj.Text = EDApi.findModuleByDisplayName("FormText"),
-			obj.Icon = EDApi.findModuleByDisplayName("Icon"),
-			obj.LoadingSpinner = EDApi.findModuleByDisplayName("Spinner"),
-			obj.Card = EDApi.findModuleByDisplayName("FormNotice"),
-			obj.Flex = EDApi.findModuleByDisplayName("Flex")
+	_initDiscordComponents(obj) {
+		const e = getReact(); 
+
+		obj.Textbox = EDApi.findModuleByDisplayName("TextInput");
+		obj.Select = EDApi.findModuleByDisplayName("SelectTempWrapper");
+		obj.Switch = EDApi.findModuleByDisplayName("SwitchItem");
+		obj.RadioGroup = EDApi.findModuleByDisplayName("RadioGroup");
+		obj.Title = EDApi.findModuleByDisplayName("FormTitle");
+		obj.Text = EDApi.findModuleByDisplayName("FormText");
+		obj.Icon = EDApi.findModuleByDisplayName("Icon");
+		obj.LoadingSpinner = EDApi.findModuleByDisplayName("Spinner");
+		obj.Card = EDApi.findModuleByDisplayName("FormNotice");
+		obj.Flex = EDApi.findModuleByDisplayName("Flex");
+		obj.Switch = EDApi.findModuleByDisplayName("Switch");
+		
+		obj.Divider = props => {
+			props.className = props.className ? props.className + " " + ED.classMaps.divider : ED.classMaps.divider
+			return e("div", Object.assign({}, props))
+		}
 	},
 	components: {
-		PluginPage () {
+		PluginsPage () {
 			const e = getReact(); 
 			return e("div")
 		},

--- a/plugins/ed_settings.js
+++ b/plugins/ed_settings.js
@@ -3,16 +3,6 @@ const BD = require('../bd_shit');
 
 const edSettingsID = require("path").parse(__filename).name;
 
-/*
-
-to do list:
-
-documentation for ED.discordComponents
-plugins.md docs
-bump ed version to 2.7.0
-
-*/
-
 module.exports = new Plugin({
 	name: 'ED Settings (React)',
 	author: 'Joe 🎸#7070 & jakuski#9191',

--- a/plugins/ed_settings.js
+++ b/plugins/ed_settings.js
@@ -21,8 +21,8 @@ const get = moduleName => {
 
 const EDSettings = {
 	name: 'ED Settings (React)',
-    author: 'Joe 🎸#7070 & jakuski#9191',
-    description: 'Adds an EnhancedDiscord tab in user settings.',
+	author: 'Joe 🎸#7070 & jakuski#9191',
+	description: 'Adds an EnhancedDiscord tab in user settings.',
 	color: 'darkred',
 	async load () {
 		const discordConstants = EDApi.findModule("API_HOST");
@@ -30,8 +30,8 @@ const EDSettings = {
 			EDApi.findModule('getUserSettingsSections').default
 		);
 
-        if (!window.ED.classMaps) {
-            window.ED.classMaps = {};
+		if (!window.ED.classMaps) {
+			window.ED.classMaps = {};
 		}
 
 		if (!window.ED.discordComponents) {
@@ -120,14 +120,14 @@ const EDSettings = {
 		}];
 	},
 	_initClassMaps(obj) {
-        const divM = EDApi.findModule(m => m.divider && Object.keys(m).length === 1)
-        obj.headers = EDApi.findModule('defaultMarginh2');
-        obj.margins = EDApi.findModule('marginBottom8');
-        obj.divider = divM ? divM.divider : '';
-        obj.checkbox = EDApi.findModule('checkboxEnabled');
-        obj.buttons = EDApi.findModule('lookFilled');
-        obj.switchItem = EDApi.findModule('switchItem');
-        obj.alignment = EDApi.findModule('horizontalReverse');
+		const divM = EDApi.findModule(m => m.divider && Object.keys(m).length === 1)
+		obj.headers = EDApi.findModule('defaultMarginh2');
+		obj.margins = EDApi.findModule('marginBottom8');
+		obj.divider = divM ? divM.divider : '';
+		obj.checkbox = EDApi.findModule('checkboxEnabled');
+		obj.buttons = EDApi.findModule('lookFilled');
+		obj.switchItem = EDApi.findModule('switchItem');
+		obj.alignment = EDApi.findModule('horizontalReverse');
 		obj.description = EDApi.findModule('formText');
 		// New
 		obj.shadows = findModule("elevationHigh");

--- a/plugins/ed_settings.js
+++ b/plugins/ed_settings.js
@@ -1,251 +1,87 @@
 const Plugin = require('../plugin');
 
-function makePluginToggle(opts = {}) {
-    const a = window.ED.classMaps.alignment;
-    const sw = window.ED.classMaps.switchItem;
-    const cb = window.ED.classMaps.checkbox;
-    const b = window.ED.classMaps.buttons;
-    const d = window.ED.classMaps.description;
-    const settingsButton = `<button type="button" class="${b.button} ${b.lookFilled} ${b.colorBrand} ed-plugin-settings" style="height:24px;margin-right:10px;"><div class="${b.contents}">Settings</div></button>`;
-
-    return `<div id="${opts.id}-wrap" class="${a.vertical} ${a.justifyStart} ${a.alignStretch} ${a.noWrap} ${sw.switchItem}" style="flex: 1 1 auto;">
-    <div class="${a.horizontal} ${a.justifyStart} ${a.alignStart} ${a.noWrap}" style="flex: 1 1 auto;">
-        <h3 class="${sw.titleDefault}" style="flex: 1 1 auto;">${opts.title}</h3>
-        ${opts.color ? ` <div class="status" style="background-color:${opts.color}; box-shadow:0 0 5px 2px ${opts.color};margin-left: 5px; border-radius: 50%; height: 10px; width: 10px; position: relative; top: 6px; margin-right: 8px;"></div>` : ''}
-        ${opts.showSettingsButton ? settingsButton : ''}
-        ${opts.id == 'bdPlugins' ? '' : `<button type="button" class="${b.button} ${b.lookFilled} ${b.colorBrand} ed-plugin-reload" style="height:24px;margin-right:10px;"><div class="${b.contents}">Reload</div></button>`}
-        <div id="${opts.id}" class="${cb.switchEnabled} ${cb.valueUnchecked} ${cb.sizeDefault} ${cb.themeDefault}">
-            <input type="checkbox" class="${cb.checkboxEnabled}" value="on">
-        </div>
-    </div>
-    <div class="${d.description} ${d.modeDefault}" style="flex: 1 1 auto;">${opts.desc ? opts.desc : '<i>No Description Provided</i<'}</div>
-    <div class="${window.ED.classMaps.divider} ${sw.dividerDefault}"></div>
-</div>`;
+const getComponentFromFluxContainer = component => {
+	return (new component({})).render().type
 }
 
-module.exports = new Plugin({
-    name: 'ED Settings',
-    author: 'Joe 🎸#7070',
+const getReact = () => window.req.c[0].exports.createElement;
+
+const EDSettings = {
+	name: 'ED Settings (React)',
+    author: 'Joe 🎸#7070 & jakuski#9191',
     description: 'Adds an EnhancedDiscord tab in user settings.',
-    color: 'darkred',
-
-    load: async function() {
-        const parentThis = this; //Allow use of parent methods in sub functions
-
+	color: 'darkred',
+	async load () {
         if (!window.ED.classMaps) {
             window.ED.classMaps = {};
-        }
-        const tabsM = window.EDApi.findModule('topPill');
-        const divM = window.EDApi.findModule(m => m.divider && Object.keys(m).length === 1)
-        const contentM = window.ED.classMaps.headers = window.EDApi.findModule('defaultMarginh2');
-        const marginM = window.ED.classMaps.margins = window.EDApi.findModule('marginBottom8');
-        const div = window.ED.classMaps.divider = divM ? divM.divider : '';
-        const cbM = window.ED.classMaps.checkbox = window.EDApi.findModule('checkboxEnabled');
-        const buttM = window.ED.classMaps.buttons = window.EDApi.findModule('lookFilled');
-        const concentCol = window.EDApi.findModule('contentColumn');
-        window.ED.classMaps.switchItem = window.EDApi.findModule('switchItem');
-        window.ED.classMaps.alignment = window.EDApi.findModule('horizontalReverse');
-        window.ED.classMaps.description = window.EDApi.findModule('formText');
+		}
 
-        // use this function to trigger the loading of the settings tabs. No MutationObservers this way :)
-        const gss = window.EDApi.findModule('getUserSettingsSections').default.prototype;
-        window.EDApi.monkeyPatch(gss, 'render', function() {
+		if (!window.ED.discordComponents) {
+			window.ED.discordComponents = {};
+		}
+		
+		this.initClassMaps(window.ED.classMaps);
+		this.initDiscordComponents(window.ED.discordComponents);
 
-            const tab = document.getElementsByClassName('ed-settings');
-            //console.log(tab);
-            if (!tab || tab.length < 1) {
-                const parent = document.querySelector('.' + tabsM.side);
-                if (!parent) {
-                    setTimeout(() => {arguments[0].thisObject.forceUpdate();}, 100);
-                    return arguments[0].callOriginalMethod(arguments[0].methodArguments);
-                }
-                const anchor = parent.querySelectorAll(`.${tabsM.separator}`)[3];
-                if (!anchor)
-                    return arguments[0].callOriginalMethod(arguments[0].methodArguments);
+		const UserSettings = getComponentFromFluxContainer(
+			EDApi.findModule('getUserSettingsSections').default
+		);
 
-                const header = document.createElement('div');
-                header.className = tabsM.header + ' ed-settings';
-                header.innerHTML = 'EnhancedDiscord';
-                anchor.parentNode.insertBefore(header, anchor.nextSibling);
+		this.unpatch = EDApi.monkeyPatch(
+			UserSettings.prototype,
+			"generateSections",
+			data => {
+				const sections = data.originalMethod.call(data.thisObject);
 
-                const pluginsTab = document.createElement('div');
-                const tabClass = `${tabsM.item} ${tabsM.themed} ed-settings`;
-                pluginsTab.className = tabClass;
-                pluginsTab.innerHTML = 'Plugins';
-                header.parentNode.insertBefore(pluginsTab, header.nextSibling);
+				sections.push({
+					section: "HEADER",
+					label: "YOU'RE GAY"
+				})
 
-                const settingsTab = document.createElement('div');
-                settingsTab.className = tabClass;
-                settingsTab.innerHTML = 'Settings';
-                pluginsTab.parentNode.insertBefore(settingsTab, pluginsTab.nextSibling);
+				return sections;
+			}
+		)
+	},
+	unload () {
+		this.unpatch();
+	},
+	initClassMaps(obj) {
+        const divM = EDApi.findModule(m => m.divider && Object.keys(m).length === 1)
+        obj.headers = EDApi.findModule('defaultMarginh2');
+        obj.margins = EDApi.findModule('marginBottom8');
+        obj.divider = divM ? divM.divider : '';
+        obj.checkbox = EDApi.findModule('checkboxEnabled');
+        obj.buttons = EDApi.findModule('lookFilled');
+        obj.switchItem = EDApi.findModule('switchItem');
+        obj.alignment = EDApi.findModule('horizontalReverse');
+        obj.description = EDApi.findModule('formText');
+	},
+	initDiscordComponents(obj) {
+			obj.Textbox = EDApi.findModuleByDisplayName("TextInput"),
+			obj.Select = EDApi.findModuleByDisplayName("SelectTempWrapper"),
+			obj.Switch = EDApi.findModuleByDisplayName("SwitchItem"),
+			obj.RadioGroup = EDApi.findModuleByDisplayName("RadioGroup"),
+			obj.Divider = EDApi.findModuleByDisplayName("FormDivider"), // FIX
+			obj.Title = EDApi.findModuleByDisplayName("FormTitle"),
+			obj.Text = EDApi.findModuleByDisplayName("FormText"),
+			obj.Icon = EDApi.findModuleByDisplayName("Icon"),
+			obj.LoadingSpinner = EDApi.findModuleByDisplayName("Spinner"),
+			obj.Card = EDApi.findModuleByDisplayName("FormNotice"),
+			obj.Flex = EDApi.findModuleByDisplayName("Flex")
+	},
+	components: {
+		PluginPage () {
+			const e = getReact(); 
+			return e("div")
+		},
+		SettingsPage () {
+			const e = getReact();
+			return e("div")
+		},
+		Plugin () {
 
-                const sep = document.createElement('div');
-                sep.className = tabsM.separator;
-                settingsTab.parentNode.insertBefore(sep, settingsTab.nextSibling);
+		}
+	}
+}
 
-                parent.onclick = function(e) {
-                    if (!e.target.className || e.target.className.indexOf(tabsM.item) == -1 || e.target.innerHTML === 'Change Log') return;
-
-                    for (const i in tab) {
-                        tab[i].className = (tab[i].className || '').replace(" " + tabsM.selected, '')
-                    }
-                }
-
-                pluginsTab.onclick = function(e) {
-                    const settingsPane = document.querySelector(`.${concentCol.standardSidebarView} .${concentCol.contentColumn} > div`);
-                    const otherTab = document.querySelector('.' + tabsM.item + '.' + tabsM.selected);
-                    if (otherTab) {
-                        otherTab.className = otherTab.className.replace(" " + tabsM.selected, '');
-                    }
-                    this.className += ` ${tabsM.selected}`;
-
-                    if (settingsPane) {
-                        // ED Header
-                        settingsPane.innerHTML = `<h2 class="${contentM.h2} ${contentM.defaultColor} ${marginM.marginBottom8}">EnhancedDiscord Plugins</h2>`;
-                        // Open Plugins Folder Button
-                        settingsPane.innerHTML += `<button id="ed-openPluginsFolder" style="margin-bottom: 10px;" class="${buttM.button} ${buttM.lookFilled} ${buttM.colorGreen} ${buttM.sizeSmall} ${buttM.grow}"><div class="${buttM.contents}">Open Plugins Directory</div></button>`;
-                        // Divider
-                        settingsPane.innerHTML += `<div class="${div} ${marginM.marginBottom20}"></div>`
-
-                        for (const id in window.ED.plugins) {
-                            //if (id == 'ed_settings') continue;
-
-                            settingsPane.innerHTML += makePluginToggle({id, title: window.ED.plugins[id].name, desc: window.ED.plugins[id].description, color: window.ED.plugins[id].color || 'orange', showSettingsButton: typeof window.ED.plugins[id].getSettingsPanel == 'function'});
-                            if (!window.ED.plugins[id].settings || window.ED.plugins[id].settings.enabled !== false) {
-                                const cb = document.getElementById(id);
-                                if (cb && cb.className)
-                                    cb.className = cb.className.replace(cbM.valueUnchecked, cbM.valueChecked);
-                            }
-                        }
-
-                        document.getElementById("ed-openPluginsFolder").onclick = function () {
-                            const s = require("electron").shell.openItem(require("path").join(process.env.injDir, "plugins"))
-                            if (s === false) console.error("[EnhancedDiscord] Unable to open external folder.")
-                        }
-                    }
-                    e.stopPropagation(); // prevent from going to parent click handler
-                }
-
-                settingsTab.onclick = function(e) {
-                    const settingsPane = document.querySelector(`.${concentCol.standardSidebarView} .${concentCol.contentColumn} > div`);
-                    const otherTab = document.querySelector('.' + tabsM.item + '.' + tabsM.selected);
-                    if (otherTab) {
-                        otherTab.className = otherTab.className.replace(" " + tabsM.selected, '');
-                    }
-                    this.className += ` ${tabsM.selected}`;
-
-                    if (settingsPane) {
-                        settingsPane.innerHTML = `<h2 class="${contentM.h2} ${contentM.defaultColor}">EnhancedDiscord Configuration</h2><div class="${div} ${marginM.marginBottom20}"></div>`;
-                        settingsPane.innerHTML += makePluginToggle({id: 'bdPlugins', title: 'BD Plugins', desc: "Allows ED to load BD plugins natively. (Reload with ctrl+r after enabling/disabling.)"});
-
-                        const bl = document.getElementById('bdPlugins');
-                        if (bl && window.ED.config.bdPlugins == true)
-                            bl.className = bl.className.replace(cbM.valueUnchecked, cbM.valueChecked);
-                        //console.log(st, at);
-                        for (const id in window.ED.plugins) {
-                            if (window.ED.plugins[id].getSettingsPanel && typeof window.ED.plugins[id].getSettingsPanel == 'function') continue;
-                            if (!window.ED.plugins[id].config || window.ED.config[id].enabled === false || !window.ED.plugins[id].generateSettings) continue;
-
-                            settingsPane.innerHTML += `<h2 class="${contentM.h2} ${contentM.defaultColor}">${window.ED.plugins[id].name}</h2>`;
-
-                            settingsPane.innerHTML += window.ED.plugins[id].generateSettings();
-
-                            settingsPane.innerHTML += `<div class="${div}"></div>`;
-                            if (window.ED.plugins[id].settingListeners) {
-                                setTimeout(() => { // let shit render
-                                        for(const eventObject in window.ED.plugins[id].settingListeners){
-                                            const currentSettingListener = window.ED.plugins[id].settingListeners[eventObject];
-                                            //Check if plugin is using the old format
-
-                                            if(Array.isArray(window.ED.plugins[id].settingListeners)){
-                                                const elem = settingsPane.querySelector(currentSettingListener.el);
-                                                if (elem)
-                                                    elem.addEventListener(currentSettingListener.type, currentSettingListener.eHandler);
-                                            } else {
-                                                const elem = settingsPane.querySelector(eventObject);
-                                                if (elem){
-                                                    parentThis.warn(`Plugin ${window.ED.plugins[id].name} is using a deprecated plugin format (New format: https://github.com/joe27g/EnhancedDiscord/blob/beta/plugins.md#advanced-plugin-functionality). Ignore this unless you're the plugin dev`)
-                                                    elem.onclick = window.ED.plugins[id].settingListeners[eventObject];
-                                                }
-                                            }
-                                        }
-                                }, 5);
-                            }
-                        }
-                    }
-                    e.stopPropagation(); // prevent from going to parent click handler
-                }
-
-                document.querySelector(`.${concentCol.standardSidebarView} .${concentCol.contentColumn}`).onclick = function(e) {
-                    const parent = e.target.parentElement;
-                    if (e.target.className && ((parent.className.indexOf && parent.className.indexOf('ed-plugin-settings') > -1) || (e.target.className.indexOf && e.target.className.indexOf('ed-plugin-settings') > -1))) {
-                        const box = e.target.className === buttM.contents ? parent.nextElementSibling.nextElementSibling : e.target.nextElementSibling.nextElementSibling;
-                        if (!box || !box.id || !window.ED.plugins[box.id] || box.className.indexOf(cbM.valueChecked) == -1 || !window.ED.config.bdPlugins) return;
-                        return require('../bd_shit').showSettingsModal(window.ED.plugins[box.id]);
-                    }
-
-                    if (e.target.className && ((parent.className.indexOf && parent.className.indexOf('ed-plugin-reload') > -1) || (e.target.className.indexOf && e.target.className.indexOf('ed-plugin-reload') > -1))) {
-                        const button = e.target.className === buttM.contents ? e.target : e.target.firstElementChild;
-                        const plugin = e.target.className === buttM.contents ? e.target.parentElement.nextElementSibling : e.target.nextElementSibling;
-                        //console.log(plugin);
-                        if (!plugin || !plugin.id || !window.ED.plugins[plugin.id] || plugin.className.indexOf(cbM.valueChecked) == -1) return;
-                        button.innerHTML = 'Reloading...';
-                        try {
-                            window.ED.plugins[plugin.id].reload();
-                            button.innerHTML = 'Reloaded!';
-                        } catch(err) {
-                            console.error(err);
-                            button.innerHTML = `Failed to reload (${err.name} - see console.)`;
-                        }
-                        setTimeout(() => {
-                            try { button.innerHTML = 'Reload'; } catch(err){/*do nothing*/}
-                        }, 3000);
-                        return;
-                    }
-
-                    if (e.target.tagName !== 'INPUT' || e.target.type !== 'checkbox' || !parent || !parent.className || !parent.id) return;
-                    const p = window.ED.plugins[parent.id];
-                    if (!p && parent.id !== 'bdPlugins') return;
-                    //console.log('settings for '+p.id, p.settings);
-
-                    if (parent.className.indexOf(cbM.valueChecked) > -1) {
-                        if (p) {
-                            if (p.settings.enabled === false) return;
-
-                            p.settings.enabled = false;
-                            window.ED.plugins[parent.id].settings = p.settings;
-                            p.unload();
-                        }
-                        else {
-                            const edc = window.ED.config;
-                            if (!edc[parent.id]) return;
-                            edc[parent.id] = false;
-                            window.ED.config = edc;
-                        }
-                        parent.className = parent.className.replace(cbM.valueChecked, cbM.valueUnchecked);
-                    } else {
-                        if (p) {
-                            if (p.settings.enabled !== false) return;
-
-                            p.settings.enabled = true;
-                            window.ED.plugins[parent.id].settings = p.settings;
-                            p.load();
-                        }
-                        else {
-                            const edc = window.ED.config;
-                            if (edc[parent.id] === true) return;
-                            edc[parent.id] = true;
-                            window.ED.config = edc;
-                        }
-                        parent.className = parent.className.replace(cbM.valueUnchecked, cbM.valueChecked);
-                    }
-                }
-            }
-            return arguments[0].callOriginalMethod(arguments[0].methodArguments);
-        })
-    },
-
-    unload: function() {
-        window.EDApi.findModule('getUserSettingsSections').default.prototype.render.unpatch();
-    }
-});
+module.exports = new Plugin(EDSettings);


### PR DESCRIPTION
Today we stand here, finally receiving what our beloved people deserve. Something that has been requested for well over a millennia. React. Based. ED. Settings.
For shall this be merged, unclean HTML templates will be a thing of the past and rightly so. People will achieve greatness with the power of React.

anyways, I'm drunk. Let's get crackinn

# What has changed in this PR
- `ed_settings.js` has been completely rewritten to use React.
- `Plugin.generateSettings` now accepts 3 new types:
    - `instanceof HTMLElement` The value returned by `document.createElement(...)`
   - `ReactNode` Any valid react element that has had `React.createElement` called on it
   - `DiscordUIElement[]` The new UI kit for ED has requested by mr joe himself. Have a looksie at the example plugins below to see how it works
   - `null` This just renders a blank space
- `ed_settings` now allows other plugins to add their own settings tabs using the `ED.plugins.ed_settings.settingsSections` property (more info on these sections is documented inside of `ed_settings.js`
- The global `ED` object now has a new property `ED.discordComponents` which has most of the popular discord components
- `ED.classMaps` has a new property `ED.classMaps.shadows`
- The `Open Plugins Dir` button will now update its text whether opening the OS file viewer was successful.
-  `ED.version` bumped to 2.7.0 in accordance with semantic versioning guidelines.
- `plugins.md` docs have been updated-ish.
- The main `readme.md` has been updated to steer dumbasses away from my repo because I cba to fix my plugins.

# Breaking changes?
None <sup>, well apart from the really really old settings style that only allowed click handlers and was deprecated within the first few updates </sup>.

# Example plugins?

[Here you goo](https://gist.github.com/jakuski/6c73c556614ca2b3ba7cfa028b469ed7)

# Known Bugs
- When using the textbox inputs provided by Discord UI generator. If the user is focused in the textbox and presses the escape key to leave user settings, the new value will not be saved as that way `onBlur` event is not fired.

# Concerns
- For performance sakes, all of the components used by ED settings are generated inside a single function which is a massive blow to readability.

<sup>*I think that's everything, so yeah.*</sup>