### PR TITLE
CSS Loader: add Glasscord compatibility

### DIFF
--- a/plugins/css_loader.js
+++ b/plugins/css_loader.js
@@ -1,6 +1,7 @@
 const Plugin = require('../plugin');
 const path = window.require('path');
 const fs = window.require('fs');
+const ipc = window.require('electron').ipcRenderer;
 
 module.exports = new Plugin({
     name: 'CSS Loader',
@@ -49,6 +50,7 @@ module.exports = new Plugin({
                 document.head.appendChild(window.customCss);
             }
             window.customCss.innerHTML = css;
+            ipc.send('glasscord_update');
             this.info('Custom CSS loaded!', window.customCss);
 
             if (window.cssWatcher == null) {


### PR DESCRIPTION
This commit adds [Glasscord](https://github.com/AryToNeX/Glasscord) integration to the CSS loader.

Glasscord is a tool for theme creators and users that enables the Discord window to be transparent without all the drawbacks that we're used to on Windows. Additional features include native compositing for Fluent Design's Blur on Windows and Vibrancy on macOS; all of this is manageable via simple CSS properties.

The project is only several days old, so if you have any question please ask me.