### PR TITLE
Fix direct download and replace double with single quotes

### DIFF
--- a/plugins/direct_download.js
+++ b/plugins/direct_download.js
@@ -7,14 +7,14 @@ const fs = require('fs');
 let ttM = {}, iteM = {};
 
 function saveAs(url, filename, fileExtension) {
-    dialog.showSaveDialog({ defaultPath: filename, title: 'Where would you like to store the stolen memes?', buttonLabel: 'Steal this meme', filters: [{ name: "Stolen meme", extensions: [fileExtension] }] })
+    dialog.showSaveDialog({ defaultPath: filename, title: 'Where would you like to store the stolen memes?', buttonLabel: 'Steal this meme', filters: [{ name: 'Stolen meme', extensions: [fileExtension] }] })
     .then(e => {
         if (!e.canceled) {
             download(url, e.filePath, () => {
                 const wrap = document.createElement('div');
                 wrap.className = 'theme-dark';
                 const gay = document.createElement('div');
-                gay.style = "position: fixed; bottom: 10%; left: calc(50% - 88px);"
+                gay.style = 'position: fixed; bottom: 10%; left: calc(50% - 88px);'
                 gay.className = `${ttM.tooltip} ${ttM.tooltipTop} ${ttM.tooltipBlack}`;
                 gay.innerHTML = 'Successfully downloaded | ' + e.filePath;
                 document.body.appendChild(wrap);
@@ -38,12 +38,25 @@ function download (url, dest, cb) {
 }
 
 function addMenuItem(url, text, filename = true, fileExtension) {
-    const cmGroups = document.getElementsByClassName(iteM.itemGroup);
+    const cmGroups = document.querySelectorAll(`.${iteM.menu} [role='group']`);
     if (!cmGroups || cmGroups.length == 0) return;
 
     const newCmItem = document.createElement('div');
-    newCmItem.className = `${iteM.item} ${iteM.clickable}`;
-    newCmItem.innerHTML = text;
+    newCmItem.className = `${iteM.item} ${iteM.labelContainer} ${iteM.colorDefault}`;
+
+    // Discord uses JS to add classes, not sure how to recreate
+    newCmItem.onmouseenter = function() {
+        this.classList.add(iteM.focused);
+    };
+    newCmItem.onmouseleave = function() {
+        this.classList.remove(iteM.focused);
+    };
+
+    const newCmItemLabel = document.createElement('div');
+    newCmItemLabel.className = iteM.label;
+    newCmItemLabel.innerText = text;
+
+    newCmItem.appendChild(newCmItemLabel);
 
     const lastGroup = cmGroups[cmGroups.length-1];
     lastGroup.appendChild(newCmItem);
@@ -59,11 +72,11 @@ module.exports = new Plugin({
     color: '#18770e',
 
     load: async function() {
-        this._cmClass = EDApi.findModule("contextMenu").contextMenu;
-        this._contClass = EDApi.findModule("embedWrapper").container;
+        this._cmClass = EDApi.findModule('hideInteraction').menu;
+        this._contClass = EDApi.findModule('embedWrapper').container;
         ttM = EDApi.findModule('tooltipPointer');
-        iteM = EDApi.findModule('itemBase');
-        document.addEventListener("contextmenu", this.listener);
+        iteM = EDApi.findModule('hideInteraction');
+        document.addEventListener('contextmenu', this.listener);
     },
     listener(e) {
         if (document.getElementsByClassName(this._cmClass).length == 0) setTimeout(() => module.exports.onContextMenu(e), 0);
@@ -72,48 +85,48 @@ module.exports = new Plugin({
     onContextMenu(e) {
         const messageGroup = e.target.closest('.'+this._contClass);
         const parentElem = e.target.parentElement;
-        const guildWrapper = EDApi.findModule('acronym').wrapper;
+        const guildWrapper = EDApi.findModule('childWrapper').wrapper;
         const memberAvatar = EDApi.findModule('nameAndDecorators').avatar;
 
-        if (e.target.localName != "a" && e.target.localName != "img" && e.target.localName != "video" && !messageGroup && !e.target.className.includes(guildWrapper) && !parentElem.className.includes(memberAvatar) && !e.target.className.includes("avatar-")) return;
+        if (e.target.localName != 'a' && e.target.localName != 'img' && e.target.localName != 'video' && !messageGroup && !e.target.className.includes(guildWrapper) && !parentElem.className.includes(memberAvatar) && !e.target.className.includes('avatar-')) return;
 
-        let saveLabel = "Download",
-            url = e.target.poster || e.target.style.backgroundImage.substring(e.target.style.backgroundImage.indexOf(`"`) + 1, e.target.style.backgroundImage.lastIndexOf(`"`)) || e.target.href || e.target.src;
+        let saveLabel = 'Download',
+            url = e.target.poster || e.target.style.backgroundImage.substring(e.target.style.backgroundImage.indexOf(`'`) + 1, e.target.style.backgroundImage.lastIndexOf(`'`)) || e.target.href || e.target.src;
 
         if (e.target.className.includes(guildWrapper)) {
-            saveLabel = "Download Icon";
+            saveLabel = 'Download Icon';
             if (e.target.firstChild.src) { // Make sure guild box has an icon
                 url = e.target.firstChild.src;
             }
         }
-        else if (e.target.className.includes("avatar-") || parentElem.className.includes(memberAvatar)) {
-            saveLabel = "Download Avatar";
+        else if (e.target.className.includes('avatar-') || (parentElem.nodeName == 'DIV' && parentElem.className.includes(memberAvatar))) {
+            saveLabel = 'Download Avatar';
             
             if (parentElem.className.includes(memberAvatar)) {
                 url = e.target.firstChild.firstChild.firstChild.src;
             }
         }
 
-        if (!url || e.target.classList.contains("emote") || url.includes("youtube.com/watch?v=") || url.includes("youtu.be/") || url.lastIndexOf("/") > url.lastIndexOf(".")) return;
+        if (!url || e.target.classList.contains('emote') || url.includes('youtube.com/watch?v=') || url.includes('youtu.be/') || url.lastIndexOf('/') > url.lastIndexOf('.')) return;
 
-        url = url.split("?")[0];
+        url = url.split('?')[0];
 
-        url = url.replace(".webp", ".png");
+        url = url.replace('.webp', '.png');
 
-        let fileName = url.substring(url.lastIndexOf("/") + 1, url.lastIndexOf("."));
-        const fileExtension = url.substr(url.lastIndexOf(".") + 1, url.length);
+        let fileName = url.substring(url.lastIndexOf('/') + 1, url.lastIndexOf('.'));
+        const fileExtension = url.substr(url.lastIndexOf('.') + 1, url.length);
 
-        if (saveLabel.includes("Avatar") || saveLabel.includes("Icon")) url += "?size=2048";
+        if (saveLabel.includes('Avatar') || saveLabel.includes('Icon')) url += '?size=2048';
 
-        if (e.target.classList.contains("emoji")) {
-            saveLabel = "Download Emoji";
-            fileName = e.target.alt.replace(/[^A-Za-z_-]/g, "");
+        if (e.target.classList.contains('emoji')) {
+            saveLabel = 'Download Emoji';
+            fileName = e.target.alt.replace(/[^A-Za-z_-]/g, '');
         }
         //console.log({url, saveLabel, fileName, fileExtension});
 
         setTimeout(() => addMenuItem(url, saveLabel, fileName, fileExtension), 5);
     },
     unload: function() {
-        document.removeEventListener("contextmenu", this.listener);
+        document.removeEventListener('contextmenu', this.listener);
     }
 });


### PR DESCRIPTION
Closes #132 

Notes:
- Discord uses JS to show a focused menu item
- Discord changed the DOM Tree for a menu item
- Double and single quotes were mixed, went for single based on [dom_shit.js](https://github.com/joe27g/EnhancedDiscord/blob/master/dom_shit.js)