### PR TITLE
Patch for Discord Electron Security Update (e.g. Canary currently)

### DIFF
--- a/dom_shit.js
+++ b/dom_shit.js
@@ -123,8 +123,11 @@ process.once('loaded', async () => {
     ED.plugins = plugins;
     c.log(`Plugins validated.`);
 
-    //while (electron.webFrame.top.context.window.webpackJsonp === 'undefined')
-		await c.sleep(250); // wait until this is loaded in order to use it for modules
+    do {
+        await c.sleep(100);
+    }
+    while (!electron.webFrame.top.context.window.webpackJsonp);
+    
 
     ED.webSocket = window._ws;
 

--- a/dom_shit.js
+++ b/dom_shit.js
@@ -1,13 +1,14 @@
-const path = window.require('path');
-const fs = window.require('fs');
-const electron = window.require('electron');
-const Module =  window.require('module').Module;
-Module.globalPaths.push(path.resolve(electron.remote.app.getAppPath(), 'node_modules'));
-const currentWindow = electron.remote.getCurrentWindow();
-if (currentWindow.__preload) {
-    process.electronBinding('command_line').appendSwitch('preload', currentWindow.__preload);
-    electron.contextBridge.exposeInMainWorld = (key, val) => window[key] = val; // Expose DiscordNative
-    require(currentWindow.__preload);
+const path = require('path');
+const fs = require('fs');
+const electron = require('electron');
+const mainProcessInfo = JSON.parse(electron.ipcRenderer.sendSync('main-process-info'));
+const Module =  require('module');
+Module.globalPaths.push(mainProcessInfo.originalNodeModulesPath);
+if (mainProcessInfo.originalPreloadScript) {
+    process.electronBinding('command_line').appendSwitch('preload', mainProcessInfo.originalPreloadScript);
+    // This hack is no longer needed due to context isolation having to be on
+    //electron.contextBridge.exposeInMainWorld = (key, val) => window[key] = val; // Expose DiscordNative
+    require(mainProcessInfo.originalPreloadScript);
 }
 
 //Get inject directory
@@ -122,13 +123,16 @@ process.once('loaded', async () => {
     ED.plugins = plugins;
     c.log(`Plugins validated.`);
 
-	while (!window.webpackJsonp)
+    //while (!electron.webFrame.top.context.window.webpackJsonp)
+        //electron.webFrame.executeJavaScript(`
+        //    preloadInfoShare.webpackJsonp = window.webpackJsonp;
+        //`);
 		await c.sleep(100); // wait until this is loaded in order to use it for modules
 
-    ED.webSocket = window._ws;
+    //ED.webSocket = window._ws;
 
-	/* Add helper functions that make plugins easy to create */
-	window.req = window.webpackJsonp.push([[], {
+    /* Add helper functions that make plugins easy to create */
+	window.req = electron.webFrame.top.context.window.webpackJsonp.push([[], {
         '__extra_id__': (module, exports, req) => module.exports = req
 	}, [['__extra_id__']]]);
 	delete window.req.m['__extra_id__'];
@@ -210,17 +214,6 @@ process.once('loaded', async () => {
     EDApi.monkeyPatch(ht, 'showToken', window.fixedShowToken);
     if (!ED.localStorage.getItem('token') && ht.getToken())
         window.fixedShowToken(); // prevent you from being logged out for no reason
-
-    // change the console warning to be more fun
-    const wc = require('electron').remote.getCurrentWebContents();
-    wc.removeAllListeners('devtools-opened');
-    wc.on('devtools-opened', () => {
-        console.log('%cHold Up!', 'color: #FF5200; -webkit-text-stroke: 2px black; font-size: 72px; font-weight: bold;');
-        console.log('%cIf you\'re reading this, you\'re probably smarter than most Discord developers.', 'font-size: 16px;');
-        console.log('%cPasting anything in here could actually improve the Discord client.', 'font-size: 18px; font-weight: bold; color: red;');
-        console.log('%cUnless you understand exactly what you\'re doing, keep this window open to browse our bad code.', 'font-size: 16px;');
-        console.log('%cIf you don\'t understand exactly what you\'re doing, you should come work with us: https://discordapp.com/jobs', 'font-size: 16px;');
-    });
 });
 
 

--- a/dom_shit.js
+++ b/dom_shit.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const electron = require('electron');
+
 const mainProcessInfo = JSON.parse(electron.ipcRenderer.sendSync('main-process-info'));
 const Module =  require('module');
 Module.globalPaths.push(mainProcessInfo.originalNodeModulesPath);
@@ -10,6 +11,8 @@ if (mainProcessInfo.originalPreloadScript) {
     //electron.contextBridge.exposeInMainWorld = (key, val) => window[key] = val; // Expose DiscordNative
     require(mainProcessInfo.originalPreloadScript);
 }
+
+//electron.ipcRenderer.sendSync('current-web-contents');
 
 //Get inject directory
 if (!process.env.injDir) process.env.injDir = __dirname;
@@ -169,7 +172,7 @@ process.once('loaded', async () => {
 
     if (ED.config.bdPlugins) {
         try {
-            await require('./bd_shit').setup(currentWindow);
+            await require('./bd_shit').setup();
             c.log(`Preparing BD plugins...`);
             for (const i in pluginFiles) {
                 if (!pluginFiles[i].endsWith('.js') || !pluginFiles[i].endsWith('.plugin.js')) continue;

--- a/dom_shit.js
+++ b/dom_shit.js
@@ -123,12 +123,12 @@ process.once('loaded', async () => {
     ED.plugins = plugins;
     c.log(`Plugins validated.`);
 
-    do {
+    // work-around to wait for webpack
+    while (true) {
         await c.sleep(100);
-    }
-    while (!electron.webFrame.top.context.window.webpackJsonp);
+        if(electron.webFrame.top.context.window && electron.webFrame.top.context.window.webpackJsonp) break;
+    };
     
-
     ED.webSocket = window._ws;
 
     /* Add helper functions that make plugins easy to create */
@@ -193,7 +193,7 @@ process.once('loaded', async () => {
             }
         }
         catch (err) {
-            c.error(`Failed to load BD plugins support: ${err}\n${err.stack}`);
+            c.warn(`Failed to load BD plugins support: ${err}\n${err.stack}`);
         }
     }
 

--- a/dom_shit.js
+++ b/dom_shit.js
@@ -123,13 +123,10 @@ process.once('loaded', async () => {
     ED.plugins = plugins;
     c.log(`Plugins validated.`);
 
-    //while (!electron.webFrame.top.context.window.webpackJsonp)
-        //electron.webFrame.executeJavaScript(`
-        //    preloadInfoShare.webpackJsonp = window.webpackJsonp;
-        //`);
-		await c.sleep(100); // wait until this is loaded in order to use it for modules
+    //while (electron.webFrame.top.context.window.webpackJsonp === 'undefined')
+		await c.sleep(250); // wait until this is loaded in order to use it for modules
 
-    //ED.webSocket = window._ws;
+    ED.webSocket = window._ws;
 
     /* Add helper functions that make plugins easy to create */
 	window.req = electron.webFrame.top.context.window.webpackJsonp.push([[], {
@@ -193,7 +190,7 @@ process.once('loaded', async () => {
             }
         }
         catch (err) {
-            c.error('Failed to load BD plugins');
+            c.error(`Failed to load BD plugins support: ${err}\n${err.stack}`);
         }
     }
 

--- a/injection.js
+++ b/injection.js
@@ -1,3 +1,4 @@
+require('./main_process_shit');
 const electron = require('electron');
 const path = require('path');
 electron.app.commandLine.appendSwitch("no-force-async-hooks-checks");
@@ -11,22 +12,28 @@ electron.session.defaultSession.webRequest.onHeadersReceived(function(details, c
 
 class BrowserWindow extends electron.BrowserWindow {
     constructor(originalOptions) {
-        if (!originalOptions || !originalOptions.webPreferences || !originalOptions.title) return super(originalOptions); // eslint-disable-line constructor-super
+        let win = new electron.BrowserWindow(originalOptions);
+        if (!originalOptions || !originalOptions.webPreferences || !originalOptions.title) return win; // eslint-disable-line constructor-super
         const originalPreloadScript = originalOptions.webPreferences.preload;
 
-        // Make sure Node integration is enabled
-        originalOptions.webPreferences.nodeIntegration = true;
-        // Make sure remote module is enabled
-        originalOptions.webPreferences.enableRemoteModule = true;
-        // Make sure context isolation is disabled
-        originalOptions.webPreferences.contextIsolation = false;
         originalOptions.webPreferences.preload = path.join(process.env.injDir, 'dom_shit.js');
         originalOptions.webPreferences.transparency = true;
 
-        super(originalOptions);
-        this.__preload = originalPreloadScript;
+        // change the console warning to be more fun
+        win.webContents.on('devtools-opened', (event) => {
+            console.log('%cHold Up!', 'color: #FF5200; -webkit-text-stroke: 2px black; font-size: 72px; font-weight: bold;');
+            console.log('%cIf you\'re reading this, you\'re probably smarter than most Discord developers.', 'font-size: 16px;');
+            console.log('%cPasting anything in here could actually improve the Discord client.', 'font-size: 18px; font-weight: bold; color: red;');
+            console.log('%cUnless you understand exactly what you\'re doing, keep this window open to browse our bad code.', 'font-size: 16px;');
+            console.log('%cIf you don\'t understand exactly what you\'re doing, you should come work with us: https://discordapp.com/jobs', 'font-size: 16px;');
+        });
+        win = new electron.BrowserWindow(originalOptions);
+        win.webContents.__preload = originalPreloadScript;
+        return win;
     }
 }
+
+BrowserWindow.webContents;
 
 const electron_path = require.resolve('electron');
 Object.assign(BrowserWindow, electron.BrowserWindow); // Assigns the new chrome-specific ones

--- a/main_process_shit.js
+++ b/main_process_shit.js
@@ -1,0 +1,20 @@
+const electron = require('electron');
+const ipcMain = require('electron').ipcMain;
+const path = require('path');
+
+ipcMain.on('main-process-info', (event, arg) => {
+    event.returnValue = `{
+        "originalNodeModulesPath": "${path.resolve(electron.app.getAppPath(), 'node_modules')}",
+        "originalPreloadScript": "${event.sender.__preload}"
+    }`
+});
+
+ipcMain.on('current-web-contents', (event, arg) => {
+    event.returnValue = event.sender.__currentWebContents
+});
+
+ipcMain.on('main-process-utils', (event, arg) => {
+    event.returnValue = `{
+        "dialog": "${electron.dialog}"
+    }`
+});

--- a/main_process_shit.js
+++ b/main_process_shit.js
@@ -9,12 +9,16 @@ ipcMain.on('main-process-info', (event, arg) => {
     }`
 });
 
-ipcMain.on('current-web-contents', (event, arg) => {
-    event.returnValue = event.sender.__currentWebContents
-});
-
 ipcMain.on('main-process-utils', (event, arg) => {
     event.returnValue = `{
         "dialog": "${electron.dialog}"
     }`
 });
+
+ipcMain.handle('bd-navigate-page-listener', (event, arg) => {
+    event.sender.getOwnerBrowserWindow().webContents.on('did-navigate-in-page', arg);
+})
+
+ipcMain.handle('remove-bd-navigate-page-listener', (event, arg) => {
+    event.sender.getOwnerBrowserWindow().webContents.removeEventListener('did-navigate-in-page', arg);
+})

--- a/plugins/avatar_links.js
+++ b/plugins/avatar_links.js
@@ -27,7 +27,8 @@ module.exports = new Plugin({
         // Make sure it's already in the DOM
         await new Promise(r => {setTimeout(r, 5)});
         const theMenu = document.querySelector('.'+cm.menu);
-        const reactData = theMenu.__reactInternalInstance$;
+
+        const reactData = theMenu[Object.keys(theMenu).find(key => key.startsWith("__reactInternalInstance") || key.startsWith("__reactFiber"))];
 
         let label = "";
         let url = "";

--- a/plugins/direct_download.js
+++ b/plugins/direct_download.js
@@ -76,20 +76,21 @@ module.exports = new Plugin({
         this._contClass = EDApi.findModule('embedWrapper').container;
         ttM = EDApi.findModule('tooltipPointer');
         iteM = EDApi.findModule('hideInteraction');
-        document.addEventListener('contextmenu', this.listener);
+        Dispatcher = EDApi.findModule("dispatch");
+        Dispatcher.subscribe("CONTEXT_MENU_OPEN", this.listener);
     },
     listener(e) {
         if (document.getElementsByClassName(this._cmClass).length == 0) setTimeout(() => module.exports.onContextMenu(e), 0);
         else this.onContextMenu(e);
     },
     onContextMenu(e) {
+        e = e.contextMenu;
         const messageGroup = e.target.closest('.'+this._contClass);
         const parentElem = e.target.parentElement;
         const guildWrapper = EDApi.findModule('childWrapper').wrapper;
         const memberAvatar = EDApi.findModule('nameAndDecorators').avatar;
-
+    
         if (e.target.localName != 'a' && e.target.localName != 'img' && e.target.localName != 'video' && !messageGroup && !e.target.className.includes(guildWrapper) && !parentElem.className.includes(memberAvatar) && !e.target.className.includes('avatar-')) return;
-
         let saveLabel = 'Download',
             url = e.target.poster || e.target.style.backgroundImage.substring(e.target.style.backgroundImage.indexOf(`'`) + 1, e.target.style.backgroundImage.lastIndexOf(`'`)) || e.target.href || e.target.src;
 
@@ -127,6 +128,6 @@ module.exports = new Plugin({
         setTimeout(() => addMenuItem(url, saveLabel, fileName, fileExtension), 5);
     },
     unload: function() {
-        document.removeEventListener('contextmenu', this.listener);
+        Dispatcher.unsubscribe("CONTEXT_MENU_OPEN", this.listener);
     }
 });

--- a/plugins/direct_download.js
+++ b/plugins/direct_download.js
@@ -1,7 +1,8 @@
 const Plugin = require('../plugin');
 
 // contains modified code from https://stackoverflow.com/a/47820271
-const { dialog } = require('electron').remote;
+const ipcRenderer = require('electron').ipcRenderer;
+const { dialog } = JSON.parse(ipcRenderer.sendSync('main-process-utils'));
 const http = require('https');
 const fs = require('fs');
 let ttM = {}, iteM = {};

--- a/plugins/ed_settings.js
+++ b/plugins/ed_settings.js
@@ -420,7 +420,7 @@ module.exports = new Plugin({
 		const DiscordUIGenerator = {
 			reactMarkdownRules: (() => {
 				const simpleMarkdown = EDApi.findModule("markdownToReact");
-				const rules = window._.clone(simpleMarkdown.defaultRules);
+				const rules = require("electron").webFrame.top.context.window._.clone(simpleMarkdown.defaultRules);
 
 				rules.paragraph.react = (node, output, state) => {
 					return e(Fragment, null, output(node.content, state))

--- a/plugins/ed_settings.js
+++ b/plugins/ed_settings.js
@@ -354,7 +354,7 @@ module.exports = new Plugin({
 
 			return e(Button, {size: Button.Sizes.SMALL, color: Button.Colors.GREEN, style: {margin: '0 5px', display: 'inline-block'}, onClick: e => {
 				setString("Opening...");
-				const sucess = require("electron").shell.openItem(
+				const sucess = require("electron").shell.openPath(
 					e.shiftKey ?
 					process.env.injDir :
 					require("path").join(process.env.injDir, "plugins")

--- a/plugins/hidden_channels.js
+++ b/plugins/hidden_channels.js
@@ -16,7 +16,7 @@ module.exports = new Plugin({
         ai = EDApi.findModule('actionIcon');
 
         const getUser = EDApi.findModule('getCurrentUser').getCurrentUser;
-        const getAllChannels = EDApi.findModule('getChannels').getChannels;
+        const getAllChannels = EDApi.findModule('getMutableGuildChannels').getMutableGuildChannels;
         const can = EDApi.findModule('computePermissions').can;
 
         g_dc = EDApi.findModule('getDefaultChannel');

--- a/plugins/hidden_channels.js
+++ b/plugins/hidden_channels.js
@@ -16,7 +16,7 @@ module.exports = new Plugin({
         ai = EDApi.findModule('actionIcon');
 
         const getUser = EDApi.findModule('getCurrentUser').getCurrentUser;
-        const getAllChannels = EDApi.findModule('getGuildChannels').getGuildChannels;
+        const getAllChannels = EDApi.findModule('getChannels').getChannels;
         const can = EDApi.findModule('computePermissions').can;
 
         g_dc = EDApi.findModule('getDefaultChannel');
@@ -137,7 +137,7 @@ module.exports = new Plugin({
             return egg;
         });*/
 
-        const cancan = EDApi.findModuleByProps('can', 'canUser').can;
+        const cancan = EDApi.findModuleByProps('can').can;
         gsr = EDApi.findModuleByDisplayName("FluxContainer(GuildSettingsRoles)").prototype;
         EDApi.monkeyPatch(gsr, 'render', b => {
             const egg = b.callOriginalMethod(b.methodArguments);

--- a/plugins/hidden_channels.js
+++ b/plugins/hidden_channels.js
@@ -16,7 +16,7 @@ module.exports = new Plugin({
         ai = EDApi.findModule('actionIcon');
 
         const getUser = EDApi.findModule('getCurrentUser').getCurrentUser;
-        const getAllChannels = EDApi.findModule('getChannels').getChannels;
+        const getAllChannels = EDApi.findModule('getGuildChannels').getGuildChannels;
         const can = EDApi.findModule('computePermissions').can;
 
         g_dc = EDApi.findModule('getDefaultChannel');


### PR DESCRIPTION
ED itself and most of the built in plugins are working again.
- ED Settings functional.
- Injection not crashing.
- Hidden channels mostly works, except no server settings option.
- Devtools custom warning text still broken.
- Stable support not harmed so far.
- Due to Discord's electron security updates (which is why a breaking patch was needed in the first place), remote module is no longer relied on by ED, and plugins can no longer use it. (as of now).
- BD Plugin support is broken, but was tweaked so it could fail w/o breaking some ED plugins (like ed settings) if it was enabled by the user.
    - Partial fix made (stuff like the on switch event is faulty atm)
- ED sometimes won't load, because I had to bypass the check for webpackJsonp, due to the way I'm accessing it not working w/ the check.
    - ~~attempt made to fix this issue~~ (failed)
    - ~~second attempt made to fix this issue~~ (failed)